### PR TITLE
Ttracy/microba 70 update footer trademarks

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -205,16 +205,16 @@ class Footer extends React.Component {
               </li>
             </ul>
             <p>
-              © 2012–2019 edX Inc.
+              © {new Date().getFullYear()} edX Inc. All rights reserved.
               <br />
               <FormattedMessage
                 id="footer.trademarks"
-                defaultMessage="EdX, Open edX, and MicroMasters are registered trademarks of edX Inc. {icpMessage}"
+                defaultMessage="{icpMessage}"
                 description="A description of the trademarks that belong to edX."
                 values={{
                   icpMessage: (
                     <React.Fragment>
-                      深圳市恒宇博科技有限公司 <a href="http://www.beian.miit.gov.cn">粤ICP备17044299号-2</a>
+                      深圳市恒宇博科技有限公司 <a style={{ textDecoration: 'underline' }} href="http://www.beian.miit.gov.cn">粤ICP备17044299号-2</a>
                     </React.Fragment>
                   ),
                 }}

--- a/src/components/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/__snapshots__/Footer.test.jsx.snap
@@ -397,13 +397,19 @@ exports[`<Footer /> renders correctly renders with a language selector 1`] = `
         </li>
       </ul>
       <p>
-        © 2012–2019 edX Inc.
+        © 
+        2019
+         edX Inc. All rights reserved.
         <br />
         <span>
-          EdX, Open edX, and MicroMasters are registered trademarks of edX Inc. 
           深圳市恒宇博科技有限公司 
           <a
             href="http://www.beian.miit.gov.cn"
+            style={
+              Object {
+                "textDecoration": "underline",
+              }
+            }
           >
             粤ICP备17044299号-2
           </a>
@@ -749,13 +755,19 @@ exports[`<Footer /> renders correctly renders without a language selector 1`] = 
         </li>
       </ul>
       <p>
-        © 2012–2019 edX Inc.
+        © 
+        2019
+         edX Inc. All rights reserved.
         <br />
         <span>
-          EdX, Open edX, and MicroMasters are registered trademarks of edX Inc. 
           深圳市恒宇博科技有限公司 
           <a
             href="http://www.beian.miit.gov.cn"
+            style={
+              Object {
+                "textDecoration": "underline",
+              }
+            }
           >
             粤ICP备17044299号-2
           </a>
@@ -1052,13 +1064,19 @@ exports[`<Footer /> renders correctly renders without a language selector in es 
         </li>
       </ul>
       <p>
-        © 2012–2019 edX Inc.
+        © 
+        2019
+         edX Inc. All rights reserved.
         <br />
         <span>
-          EdX, Open edX, and MicroMasters are registered trademarks of edX Inc. 
           深圳市恒宇博科技有限公司 
           <a
             href="http://www.beian.miit.gov.cn"
+            style={
+              Object {
+                "textDecoration": "underline",
+              }
+            }
           >
             粤ICP备17044299号-2
           </a>


### PR DESCRIPTION
Copyright change for the footer.

<img width="1304" alt="image" src="https://user-images.githubusercontent.com/16495365/70737647-05474e80-1ce1-11ea-9902-e25d6b231d71.png">

The underline style on the ICP message was a request to match the style to every other footer.