### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 frontend-component-footer-edx
-=========================
+=============================
 
 |Build Status| |Coveralls| |npm_version| |npm_downloads| |license|
 |semantic-release|
@@ -48,8 +48,8 @@ Build the component::
 
    npm run build
 
-.. |Build Status| image:: https://api.travis-ci.org/edx/frontend-component-footer-edx.svg?branch=master
-   :target: https://travis-ci.org/edx/frontend-component-footer-edx
+.. |Build Status| image:: https://api.travis-ci.com/edx/frontend-component-footer-edx.svg?branch=master
+   :target: https://travis-ci.com/edx/frontend-component-footer-edx
 .. |Coveralls| image:: https://img.shields.io/coveralls/edx/frontend-component-footer-edx.svg?branch=master
    :target: https://coveralls.io/github/edx/frontend-component-footer-edx
 .. |npm_version| image:: https://img.shields.io/npm/v/@edx/frontend-component-footer-edx.svg


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089