### PR TITLE
fix: remove extraneous border line

### DIFF
--- a/src/_footer.scss
+++ b/src/_footer.scss
@@ -126,7 +126,7 @@ $border-1: 1px solid $gray-200;
     .area-5 {
       grid-column: 2 / span 3;
       grid-row: 2;
-      border: none;
+      border-left: none;
       margin-left: 0;
       padding-left: 0;
     }


### PR DESCRIPTION
Area 5 would have a bogus left-border line on large screen sizes.

As far as I can tell, this is because it tried to reset the border that smaller-screen-size css would set (border-left: $border-1) with a 'border: none'. But the border-left instruction would still win css precedence rules because it an ltr/rtl direction defined.

Changing the 'border: none' to a 'border-left: none', explicitly only undoing the smaller-screen-size css, seems to fix this extra line.

Before:
![Screenshot from 2022-03-28 15-29-33](https://user-images.githubusercontent.com/1196901/160472393-7cb5cc8a-0510-40e9-b1a8-31b3aa4ad0f9.png)

After:
![Screenshot from 2022-03-28 15-29-51](https://user-images.githubusercontent.com/1196901/160472448-629eba36-1405-4d3f-a914-95855b9edb8c.png)

After on smaller width where the line *should* and *still does* appear:
![Screenshot from 2022-03-28 15-30-28](https://user-images.githubusercontent.com/1196901/160472540-1bf25ca1-9189-44d8-9f0f-b716947fe921.png)
