### PR TITLE
feat: update peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,9 @@
   },
   "peerDependencies": {
     "@edx/frontend-platform": "^2.4.0",
+    "@edx/paragon": "^19.9.0 || ^20.0.0",
     "prop-types": "^15.7.0",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0"
+    "react": "^16.9.0 || ^17.0.0",
+    "react-dom": "^16.9.0 || ^17.0.0"
   }
 }


### PR DESCRIPTION
This broke a lot of pipe line because project specify peer dependency to `paragon@^19.9.0`. At the time of this PR, the latest paragon is `20.5.0`.
