### PR TITLE
feat: Add footer link for cookie compliance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@fortawesome/free-brands-svg-icons": "5.15.4",
         "@fortawesome/free-regular-svg-icons": "5.15.4",
         "@fortawesome/free-solid-svg-icons": "5.15.4",
-        "@fortawesome/react-fontawesome": "0.2.0"
+        "@fortawesome/react-fontawesome": "0.2.0",
+        "js-cookie": "^3.0.1"
       },
       "devDependencies": {
         "@edx/brand": "npm:@edx/brand-edx.org@2.0.8",
@@ -15022,6 +15023,14 @@
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -34692,6 +34701,11 @@
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
       "dev": true,
       "peer": true
+    },
+    "js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "@fortawesome/free-brands-svg-icons": "5.15.4",
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
-    "@fortawesome/react-fontawesome": "0.2.0"
+    "@fortawesome/react-fontawesome": "0.2.0",
+    "js-cookie": "^3.0.1"
   },
   "peerDependencies": {
     "@edx/frontend-platform": "^2.0.0 || ^3.0.0",

--- a/src/_footer.scss
+++ b/src/_footer.scss
@@ -29,10 +29,10 @@
   }
   background-color: transparent !important;
   border: none !important;
-  font-family: "Inter", "Helvetica Neue", Arial, sans-serif !important;
+  font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif !important;
   font-size: 1.125rem !important;
   font-weight: 400 !important;
-  color:  #00688D !important;
+  color: #00688d !important;
   padding: 0 !important;
 
   &.hide-one-trust {

--- a/src/_footer.scss
+++ b/src/_footer.scss
@@ -34,6 +34,10 @@
   font-weight: 400 !important;
   color:  #00688D !important;
   padding: 0 !important;
+
+  &.hide-one-trust {
+    display: none !important;
+  }
 }
 
 $gray-footer: #fcfcfc;

--- a/src/_footer.scss
+++ b/src/_footer.scss
@@ -18,6 +18,24 @@
   display: grid;
 }
 
+/* Override the default settings */
+.ot-sdk-show-settings {
+  &:hover {
+    color: #004972 !important;
+    text-decoration: underline !important;
+  }
+  &:focus::before {
+    border: none !important;
+  }
+  background-color: transparent !important;
+  border: none !important;
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif !important;
+  font-size: 1.125rem !important;
+  font-weight: 400 !important;
+  color:  #00688D !important;
+  padding: 0 !important;
+}
+
 $gray-footer: #fcfcfc;
 $border-1: 1px solid $gray-200;
 

--- a/src/_footer.scss
+++ b/src/_footer.scss
@@ -185,3 +185,9 @@ $border-1: 1px solid $gray-200;
     }
   }
 }
+
+.ccpa-dialog .pgn__form-switch-input {
+  flex-shrink: 0;
+  margin-right: 0;
+  align-self: center;
+}

--- a/src/components/CCPADialog.jsx
+++ b/src/components/CCPADialog.jsx
@@ -1,0 +1,145 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import {
+  ModalDialog, Form, useToggle, ActionRow, Button,
+} from '@edx/paragon';
+import Cookies from 'js-cookie';
+
+const CCPA_COOKIE_NAME = 'edx_do_not_sell';
+
+function CCPADialog({ dialogIsOpen, closeCallback, baseURL }) {
+  const [isOpen, open, close] = useToggle(dialogIsOpen);
+
+  const getDoNotSellCookie = () => Cookies.get(CCPA_COOKIE_NAME) === 'true';
+  const [personalizationChecked, setPersonalizationChecked] = useState(() => !getDoNotSellCookie());
+
+  useEffect(() => {
+    if (dialogIsOpen) {
+      setPersonalizationChecked(!getDoNotSellCookie());
+      open();
+    }
+  }, [dialogIsOpen, open]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      closeCallback();
+    }
+  }, [closeCallback, isOpen]);
+
+  const setDoNotSellCookie = (value) => {
+    const { host } = new URL(baseURL);
+    const cookieOptions = host.startsWith('localhost')
+      ? {}
+      : { domain: host, expires: 365 };
+    if (!value) {
+      // If cookie is not set to true, then default to sharing the data
+      Cookies.remove(CCPA_COOKIE_NAME, cookieOptions);
+      return;
+    }
+    Cookies.set(CCPA_COOKIE_NAME, value, cookieOptions);
+  };
+
+  const handleSwitchChange = (e) => {
+    setPersonalizationChecked(e.target.checked);
+  };
+
+  const handleConfirmation = () => {
+    if (typeof window === 'object' && getDoNotSellCookie() === personalizationChecked) {
+      setDoNotSellCookie(!personalizationChecked);
+      window.location.reload();
+    }
+    close();
+  };
+
+  return (
+    <ModalDialog
+      title="Do Not Sell My Personal Data"
+      isOpen={isOpen}
+      onClose={close}
+      size="xl"
+      variant="default"
+      hasCloseButton
+      className="ccpa-dialog"
+    >
+      <ModalDialog.Header>
+        <ModalDialog.Title>
+          <FormattedMessage
+            id="prospectus.data.sharing.modal.title"
+            description="CCPA Data sharing dialog title"
+            defaultMessage="Do Not Sell My Personal Data"
+          />
+        </ModalDialog.Title>
+      </ModalDialog.Header>
+      <ModalDialog.Body>
+        <Form.Group>
+          <Form.Switch
+            className="h4"
+            checked={personalizationChecked}
+            onChange={handleSwitchChange}
+            floatLabelLeft
+          >
+            <FormattedMessage
+              id="prospectus.data.sharing.modal.toggle.title"
+              description="CCPA Data sharing dialog toggle title"
+              defaultMessage="Share My Data with Third Parties for Personalized Advertising"
+            />
+          </Form.Switch>
+        </Form.Group>
+        <div>
+          <FormattedMessage
+            id="prospectus.data.sharing.modal.description"
+            description="CCPA Data sharing dialog description"
+            defaultMessage="We share information with business partners to provide personalized
+              online advertising. Under the California Consumer Privacy Act
+              (“CCPA”), some of this data sharing may be broadly considered a “sale”
+              of information. Except for this type of sharing, we do not sell your
+              information. You may opt out of these “sales” under the CCPA. Your
+              selection is saved to this browser, on this device. If you clear your
+              browser cookies, you will need to opt out of “sales” again. To learn
+              more about 2U's use of your data, please see our"
+          />{' '}
+          <a href={`${baseURL}/edx-privacy-policy`}>
+            <FormattedMessage
+              id="prospectus.data.sharing.modal.privacy-policy.link.title"
+              description="CCPA Data sharing dialog toggle title"
+              defaultMessage="Privacy Policy."
+            />
+          </a>
+        </div>
+      </ModalDialog.Body>
+      <ModalDialog.Footer>
+        <ActionRow>
+          <ModalDialog.CloseButton variant="tertiary">
+            <FormattedMessage
+              id="prospectus.data.sharing.modal.cancel.title"
+              description="CCPA Data sharing dialog cancel button title"
+              defaultMessage="Cancel"
+            />
+          </ModalDialog.CloseButton>
+          <Button variant="primary" onClick={handleConfirmation}>
+            <FormattedMessage
+              id="prospectus.data.sharing.modal.confirm.title"
+              description="CCPA Data sharing dialog confirmation button title"
+              defaultMessage="Confirm"
+            />
+          </Button>
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
+  );
+}
+
+CCPADialog.propTypes = {
+  dialogIsOpen: PropTypes.bool,
+  closeCallback: PropTypes.func,
+  baseURL: PropTypes.string,
+};
+
+CCPADialog.defaultProps = {
+  dialogIsOpen: false,
+  closeCallback: () => {},
+  baseURL: 'https://edx.org',
+};
+
+export default CCPADialog;

--- a/src/components/CCPADialog.jsx
+++ b/src/components/CCPADialog.jsx
@@ -8,7 +8,7 @@ import Cookies from 'js-cookie';
 
 const CCPA_COOKIE_NAME = 'edx_do_not_sell';
 
-function CCPADialog({ dialogIsOpen, closeCallback, baseURL }) {
+const CCPADialog = ({ dialogIsOpen, closeCallback, baseURL }) => {
   const [isOpen, open, close] = useToggle(dialogIsOpen);
 
   const getDoNotSellCookie = () => Cookies.get(CCPA_COOKIE_NAME) === 'true';
@@ -29,9 +29,14 @@ function CCPADialog({ dialogIsOpen, closeCallback, baseURL }) {
 
   const setDoNotSellCookie = (value) => {
     const { host } = new URL(baseURL);
+    // Use global domain (`.edx.org`) without the subdomain
+    const hostParts = host.split('.');
+    const domain = hostParts.length > 2
+      ? `.${hostParts.slice(-2).join('.')}`
+      : host;
     const cookieOptions = host.startsWith('localhost')
       ? {}
-      : { domain: host, expires: 365 };
+      : { domain, expires: 365 };
     if (!value) {
       // If cookie is not set to true, then default to sharing the data
       Cookies.remove(CCPA_COOKIE_NAME, cookieOptions);
@@ -128,7 +133,7 @@ function CCPADialog({ dialogIsOpen, closeCallback, baseURL }) {
       </ModalDialog.Footer>
     </ModalDialog>
   );
-}
+};
 
 CCPADialog.propTypes = {
   dialogIsOpen: PropTypes.bool,

--- a/src/components/CCPADialog.test.jsx
+++ b/src/components/CCPADialog.test.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import renderer from 'react-test-renderer';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { mount } from 'enzyme';
+
+import CCPADialog from './CCPADialog';
+
+describe('CCPADialog', () => {
+  describe('Functionality', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('Toggle off data sharing sets the cookie', () => {
+      const cookieSetSpy = jest.spyOn(window.document, 'cookie', 'set');
+      const reloadMock = jest.fn();
+      delete window.location;
+      window.location = { reload: reloadMock };
+      const wrapper = mount(
+        <IntlProvider locale="en">
+          <CCPADialog dialogIsOpen baseURL="http://localhost" />
+        </IntlProvider>,
+      );
+      const toggleInput = wrapper.find('.pgn__form-switch-input');
+      toggleInput.simulate('change', { target: { checked: false } });
+
+      const confirmButton = wrapper.findWhere(
+        (node) => node.type() === 'button' && node.text().includes('Confirm'),
+      );
+      confirmButton.simulate('click');
+      expect(wrapper.html()).toEqual('');
+      expect(cookieSetSpy).toHaveBeenCalledWith('edx_do_not_sell=true; path=/');
+      expect(reloadMock).toBeCalled();
+    });
+
+    it('Toggle on data sharing removes the cookie', () => {
+      document.cookie = 'edx_do_not_sell=true; path=/';
+      const cookieSetSpy = jest.spyOn(window.document, 'cookie', 'set');
+      const reloadMock = jest.fn();
+      delete window.location;
+      window.location = { reload: reloadMock };
+      const wrapper = mount(
+        <IntlProvider locale="en">
+          <CCPADialog dialogIsOpen />
+        </IntlProvider>,
+      );
+      const toggleInput = wrapper.find('.pgn__form-switch-input');
+      toggleInput.simulate('change', { target: { checked: true } });
+
+      const confirmButton = wrapper.findWhere(
+        (node) => node.type() === 'button' && node.text().includes('Confirm'),
+      );
+      confirmButton.simulate('click');
+      expect(wrapper.html()).toEqual('');
+      expect(cookieSetSpy).toBeCalled();
+      expect(reloadMock).toBeCalled();
+    });
+
+    it('Cancel button closes the dialog', () => {
+      const wrapper = mount(
+        <IntlProvider locale="en">
+          <CCPADialog dialogIsOpen />
+        </IntlProvider>,
+      );
+      const cancelButton = wrapper.findWhere(
+        (node) => node.type() === 'button' && node.text().includes('Cancel'),
+      );
+      cancelButton.simulate('click');
+      expect(wrapper.html()).toEqual('');
+    });
+
+    it('Close button closes the dialog', async () => {
+      const wrapper = mount(
+        <IntlProvider locale="en">
+          <CCPADialog dialogIsOpen />
+        </IntlProvider>,
+      );
+      wrapper.update();
+      const closeButton = wrapper.find('[aria-label="Close"]');
+      closeButton.simulate('click');
+      expect(wrapper.html()).toEqual('');
+    });
+  });
+
+  describe('Snapshots', () => {
+    it('Dialog is open', () => {
+      function createNodeMock(element) {
+        if (element.type === 'div') {
+          return document.createElement('div');
+        }
+        return null;
+      }
+      const oldPortal = ReactDOM.createPortal;
+      ReactDOM.createPortal = (node) => node;
+      const tree = renderer
+        .create(
+          ReactDOM.createPortal(
+            <IntlProvider locale="en">
+              <CCPADialog dialogIsOpen />
+            </IntlProvider>,
+          ),
+          { createNodeMock },
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+      ReactDOM.createPortal = oldPortal;
+    });
+    it('Dialog is closed', () => {
+      const tree = renderer
+        .create(<CCPADialog dialogIsOpen={false} />)
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -16,6 +16,7 @@ import GooglePlayStoreButton from './GooglePlayStoreButton';
 import SocialIconLinks from './SocialIconLinks';
 import messages from './Footer.messages';
 import LanguageSelector from './LanguageSelector';
+import CCPADialog from './CCPADialog';
 
 ensureConfig([
   'LOGO_TRADEMARK_URL',
@@ -39,10 +40,13 @@ class Footer extends React.Component {
   constructor(props) {
     super(props);
     this.externalLinkClickHandler = this.externalLinkClickHandler.bind(this);
+    this.CCPADialogCloseHandler = this.CCPADialogCloseHandler.bind(this);
+    this.CCPADialogOpen = this.CCPADialogOpen.bind(this);
 
     this.state = {
       // Used for constructing the enterprise market link.
       utmSource: 'edx.org',
+      showCCPADialog: false,
     };
   }
 
@@ -71,6 +75,18 @@ class Footer extends React.Component {
       label,
     };
     sendTrackEvent(eventName, properties);
+  }
+
+  CCPADialogCloseHandler() {
+    this.setState({
+      showCCPADialog: false,
+    });
+  }
+
+  CCPADialogOpen() {
+    this.setState({
+      showCCPADialog: true,
+    });
   }
 
   render() {
@@ -176,7 +192,8 @@ class Footer extends React.Component {
                 title: intl.formatMessage(messages['footer.doNotSellData']),
                 id: 'ot-sdk-btn',
                 className: `ot-sdk-show-settings ${typeof OneTrust === 'undefined' && 'hide-one-trust'}`,
-              }
+                onClick: this.CCPADialogOpen,
+              },
             ]}
           />
           <LinkList
@@ -236,6 +253,11 @@ class Footer extends React.Component {
             </p>
           </div>
         </div>
+        <CCPADialog
+          dialogIsOpen={this.state.showCCPADialog}
+          closeCallback={this.CCPADialogCloseHandler}
+          baseURL={`${MARKETING_BASE_URL}${localePrefix}`}
+        />
       </footer>
     );
   }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -172,6 +172,12 @@ class Footer extends React.Component {
                 title: intl.formatMessage(messages['footer.legalLinks.sitemap']),
                 hidden: intl.locale === 'es',
               },
+              {
+                title: 'Do not sell my personal data',
+                id: 'ot-sdk-btn',
+                className: 'ot-sdk-show-settings',
+
+              }
             ]}
           />
           <LinkList

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -173,10 +173,9 @@ class Footer extends React.Component {
                 hidden: intl.locale === 'es',
               },
               {
-                title: 'Do not sell my personal data',
+                title: intl.formatMessage(messages['footer.doNotSellData']),
                 id: 'ot-sdk-btn',
-                className: 'ot-sdk-show-settings',
-
+                className: `ot-sdk-show-settings ${typeof OneTrust === 'undefined' && 'hide-one-trust'}`,
               }
             ]}
           />

--- a/src/components/Footer.messages.js
+++ b/src/components/Footer.messages.js
@@ -156,6 +156,11 @@ const messages = defineMessages({
     defaultMessage: 'Page Footer',
     description: 'aria-label for the footer component',
   },
+  'footer.doNotSellData': {
+    id: 'footer.doNotSellData',
+    defaultMessage: 'Do Not Sell My Personal Data',
+    description: 'link button that leads to the cookie settings menu',
+  }
 });
 
 export default messages;

--- a/src/components/Footer.messages.js
+++ b/src/components/Footer.messages.js
@@ -160,7 +160,7 @@ const messages = defineMessages({
     id: 'footer.doNotSellData',
     defaultMessage: 'Do Not Sell My Personal Data',
     description: 'link button that leads to the cookie settings menu',
-  }
+  },
 });
 
 export default messages;

--- a/src/components/LinkList.jsx
+++ b/src/components/LinkList.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Button } from '@edx/paragon';
 
 const LinkList = ({
   title: listTitle, links = [], ...props
@@ -12,6 +13,13 @@ const LinkList = ({
       }) => {
         if (hidden) {
           return null;
+        }
+        if (!href) {
+          return (
+            <li key={`${title}`}>
+              <Button {...linkProps}>{title}</Button>
+            </li>
+          )
         }
         return (
           <li key={`${href}${title}`} {...linkProps}>

--- a/src/components/LinkList.jsx
+++ b/src/components/LinkList.jsx
@@ -19,7 +19,7 @@ const LinkList = ({
             <li key={`${title}`}>
               <Button {...linkProps}>{title}</Button>
             </li>
-          )
+          );
         }
         return (
           <li key={`${href}${title}`} {...linkProps}>

--- a/src/components/__snapshots__/CCPADialog.test.jsx.snap
+++ b/src/components/__snapshots__/CCPADialog.test.jsx.snap
@@ -1,0 +1,180 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CCPADialog Snapshots Dialog is closed 1`] = `null`;
+
+exports[`CCPADialog Snapshots Dialog is open 1`] = `
+Array [
+  <div
+    data-focus-guard={true}
+    style={
+      Object {
+        "height": "0px",
+        "left": "1px",
+        "overflow": "hidden",
+        "padding": 0,
+        "position": "fixed",
+        "top": "1px",
+        "width": "1px",
+      }
+    }
+    tabIndex={0}
+  />,
+  <div
+    className="pgn__modal-layer"
+    data-focus-lock-disabled={false}
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onScrollCapture={[Function]}
+    onTouchMoveCapture={[Function]}
+    onTouchStart={[Function]}
+    onWheelCapture={[Function]}
+  >
+    <div
+      className="pgn__modal-content-container"
+    >
+      <div
+        className="pgn__modal-backdrop"
+        onClick={[Function]}
+      />
+      <div
+        aria-label="Do Not Sell My Personal Data"
+        className="pgn__modal pgn__modal-xl pgn__modal-default ccpa-dialog"
+        role="dialog"
+      >
+        <div
+          className="pgn__modal-close-container"
+        >
+          <button
+            aria-label="Close"
+            className="btn-icon btn-icon-primary btn-icon-md pgn__modal-close-button"
+            onClick={[Function]}
+            type="button"
+          >
+            <span
+              className="btn-icon__icon-container"
+            >
+              <span
+                className="pgn__icon btn-icon__icon"
+              >
+                <svg
+                  aria-hidden={true}
+                  fill="none"
+                  focusable={false}
+                  height={24}
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width={24}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+            </span>
+          </button>
+        </div>
+        <div
+          className="pgn__modal-header"
+        >
+          <h2
+            className="pgn__modal-title"
+          >
+            Do Not Sell My Personal Data
+          </h2>
+        </div>
+        <div
+          className="pgn__modal-body pgn__modal-body-scroll-top pgn__modal-body-scroll-bottom"
+        >
+          <div />
+          <div
+            className="pgn__modal-body-content"
+          >
+            <div
+              className="pgn__form-group"
+            >
+              <div
+                className="d-inline-flex flex-column"
+              >
+                <div
+                  className="pgn__form-checkbox pgn__form-switch h4 pgn__form-control-label-left"
+                  id="form-field13"
+                  role="group"
+                >
+                  <input
+                    checked={false}
+                    className="pgn__form-switch-input"
+                    id="form-field14"
+                    onChange={[Function]}
+                    role="switch"
+                    type="checkbox"
+                  />
+                  <div>
+                    <label
+                      className="pgn__form-label"
+                      htmlFor="form-field14"
+                    >
+                      Share My Data with Third Parties for Personalized Advertising
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div>
+              We share information with business partners to provide personalized online advertising. Under the California Consumer Privacy Act (“CCPA”), some of this data sharing may be broadly considered a “sale” of information. Except for this type of sharing, we do not sell your information. You may opt out of these “sales” under the CCPA. Your selection is saved to this browser, on this device. If you clear your browser cookies, you will need to opt out of “sales” again. To learn more about 2U's use of your data, please see our
+               
+              <a
+                href="https://edx.org/edx-privacy-policy"
+              >
+                Privacy Policy.
+              </a>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          className="pgn__modal-footer"
+        >
+          <div
+            className="pgn__action-row"
+          >
+            <button
+              className="pgn__modal-close-button btn btn-tertiary"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="btn btn-primary"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              Confirm
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    data-focus-guard={true}
+    style={
+      Object {
+        "height": "0px",
+        "left": "1px",
+        "overflow": "hidden",
+        "padding": 0,
+        "position": "fixed",
+        "top": "1px",
+        "width": "1px",
+      }
+    }
+    tabIndex={0}
+  />,
+]
+`;

--- a/src/components/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/__snapshots__/Footer.test.jsx.snap
@@ -183,6 +183,17 @@ exports[`<Footer /> renders correctly renders with a language selector 1`] = `
             Sitemap
           </a>
         </li>
+        <li>
+          <button
+            className="ot-sdk-show-settings hide-one-trust btn btn-primary"
+            disabled={false}
+            id="ot-sdk-btn"
+            onClick={[Function]}
+            type="button"
+          >
+            Do Not Sell My Personal Data
+          </button>
+        </li>
       </ul>
     </div>
     <div
@@ -576,6 +587,17 @@ exports[`<Footer /> renders correctly renders without a language selector 1`] = 
             Sitemap
           </a>
         </li>
+        <li>
+          <button
+            className="ot-sdk-show-settings hide-one-trust btn btn-primary"
+            disabled={false}
+            id="ot-sdk-btn"
+            onClick={[Function]}
+            type="button"
+          >
+            Do Not Sell My Personal Data
+          </button>
+        </li>
       </ul>
     </div>
     <div
@@ -933,6 +955,17 @@ exports[`<Footer /> renders correctly renders without a language selector in es 
           >
             Accessibility Policy
           </a>
+        </li>
+        <li>
+          <button
+            className="ot-sdk-show-settings hide-one-trust btn btn-primary"
+            disabled={false}
+            id="ot-sdk-btn"
+            onClick={[Function]}
+            type="button"
+          >
+            Do Not Sell My Personal Data
+          </button>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
This isn't my favorite solution, but can work for now. If the cookie banner code is not injected onto the page, the button in the footer will do nothing, which is not ideal. Also, the forced styling is a result of the settings button in OneTrust not being style-able.

Custom CCPADialog for opting out from sharing user data.

You can preview it by clicking **Do Not Sell My Personal Data** in the footer.
![image](https://user-images.githubusercontent.com/2293236/203789774-6a6a5426-c074-4dc2-a091-3c6698c2ce6c.png)

### JIRA:

https://2u-internal.atlassian.net/browse/SEO-219

### Screenshots:
![image](https://user-images.githubusercontent.com/2293236/203744645-1fe86a23-f80c-4569-946b-f4ef4851925d.png)
![image](https://user-images.githubusercontent.com/2293236/203744456-e3c5c121-4efe-4b0f-8362-65134f0933fe.png)
![image](https://user-images.githubusercontent.com/2293236/203744309-bbfd9a83-1fe7-43fb-9d89-2d2617ff20f9.png)
