### PR TITLE
feat: update frontend platform to version 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@edx/brand": "npm:@edx/brand-edx.org@2.0.8",
         "@edx/browserslist-config": "^1.1.1",
         "@edx/frontend-build": "12.4.0",
-        "@edx/frontend-platform": "^2.0.0 || ^3.0.0",
+        "@edx/frontend-platform": "^3.2.0",
         "@edx/paragon": "20.20.0",
         "@edx/reactifex": "2.1.1",
         "codecov": "3.8.3",
@@ -2069,9 +2069,9 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-3.1.1.tgz",
-      "integrity": "sha512-vXpuOISGuTpzN7PAGCmvZ1XFxgnsVyc9/WA/IcAFPZaNKsjbTOtDn5oiFI9avjWKSnlFqsvJTYUK9JfPOSNW5A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-3.2.0.tgz",
+      "integrity": "sha512-fEAd9RuaN22v8f9X+g52JOaMQklfvDthiENS7X2woV/MO/m3CdN4sPsV7o8gab0cDWgLmLA1Kz0zPhvkTgqQyQ==",
       "dev": true,
       "dependencies": {
         "@cospired/i18n-iso-languages": "2.2.0",
@@ -22037,9 +22037,9 @@
       }
     },
     "@edx/frontend-platform": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-3.1.1.tgz",
-      "integrity": "sha512-vXpuOISGuTpzN7PAGCmvZ1XFxgnsVyc9/WA/IcAFPZaNKsjbTOtDn5oiFI9avjWKSnlFqsvJTYUK9JfPOSNW5A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-3.2.0.tgz",
+      "integrity": "sha512-fEAd9RuaN22v8f9X+g52JOaMQklfvDthiENS7X2woV/MO/m3CdN4sPsV7o8gab0cDWgLmLA1Kz0zPhvkTgqQyQ==",
       "dev": true,
       "requires": {
         "@cospired/i18n-iso-languages": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@edx/brand": "npm:@edx/brand-edx.org@2.0.8",
     "@edx/browserslist-config": "^1.1.1",
     "@edx/frontend-build": "12.4.0",
-    "@edx/frontend-platform": "^2.0.0 || ^3.0.0",
+    "@edx/frontend-platform": "^3.2.0",
     "@edx/paragon": "20.20.0",
     "@edx/reactifex": "2.1.1",
     "codecov": "3.8.3",
@@ -60,7 +60,7 @@
     "@fortawesome/react-fontawesome": "0.2.0"
   },
   "peerDependencies": {
-    "@edx/frontend-platform": "^2.0.0 || ^3.0.0",
+    "@edx/frontend-platform": "^3.0.0",
     "prop-types": "^15.7.0",
     "react": "^16.9.0 || ^17.0.0",
     "react-dom": "^16.9.0 || ^17.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-export { default, default as Footer, EVENT_NAMES } from './components/Footer'; // eslint-disable-line no-restricted-exports
+export { default as Footer, EVENT_NAMES } from './components/Footer';
 export { default as messages } from './i18n/index';


### PR DESCRIPTION
update frontend platform to version 3.

BREAKING CHANGE:
- We are no longer support frontend-platform@2
- We are no longer support default import.
  - please use `import { Footer } from '@edx/frontend-component-footer';`
  - revert https://github.com/edx/frontend-component-footer-edx/pull/232