### PR TITLE
fix: make footer export backward compat

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-export { default as Footer, EVENT_NAMES } from './components/Footer';
+export { default, default as Footer, EVENT_NAMES } from './components/Footer'; // eslint-disable-line no-restricted-exports
 export { default as messages } from './i18n/index';


### PR DESCRIPTION
Add backward compatibility for footer from https://github.com/edx/frontend-component-footer-edx/pull/196/files. Although the change was valid, I would that is a breaking change and bump the version 5. 

The error was very unintuitive on stage/prod:
![Screen Shot 2022-12-12 at 2 56 58 PM](https://user-images.githubusercontent.com/83240113/207147853-7590d413-6353-483d-8e80-7df3dde6e34c.png)
