### PR TITLE
fix: add cookie policy link to legal footer section

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -1,0 +1,40 @@
+name: Manual Publish
+on: [workflow_dispatch]
+jobs:
+  release:
+    name: Manual Publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Setup Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: 16
+    - name: Install dependencies
+      run: npm ci
+    - name: Validate package-lock.json changes
+      run: make validate-no-uncommitted-package-lock-changes
+    - name: Lint
+      run: npm run lint
+    - name: Test
+      run: npm run test
+    - name: i18n_extract
+      run: npm run i18n_extract
+    - name: Coverage
+      uses: codecov/codecov-action@v2
+    - name: Build
+      run: npm run build
+    # NPM expects to be authenticated for publishing. This step will fail CI if NPM is not authenticated
+    - name: Check NPM authentication
+      run: |
+        echo "//registry.npmjs.org/:_authToken=${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}" >> .npmrc
+        npm whoami
+    - name: Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
+      # `npm publish` relies on version specified in package.json file
+      run: npm publish --tag old-version

--- a/src/_footer.scss
+++ b/src/_footer.scss
@@ -18,24 +18,6 @@
   display: grid;
 }
 
-/* Override the default settings */
-.ccpa-show-settings {
-  &:hover {
-    color: #004972 !important;
-    text-decoration: underline !important;
-  }
-  &:focus::before {
-    border: none !important;
-  }
-  background-color: transparent !important;
-  border: none !important;
-  font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif !important;
-  font-size: 1.125rem !important;
-  font-weight: 400 !important;
-  color: #00688d !important;
-  padding: 0 !important;
-}
-
 $gray-footer: #fcfcfc;
 $border-1: 1px solid $gray-200;
 
@@ -180,10 +162,4 @@ $border-1: 1px solid $gray-200;
       max-width: 372px;
     }
   }
-}
-
-.ccpa-dialog .pgn__form-switch-input {
-  flex-shrink: 0;
-  margin-right: 0;
-  align-self: center;
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -189,9 +189,15 @@ class Footer extends React.Component {
                 hidden: intl.locale === 'es',
               },
               {
-                title: intl.formatMessage(messages['footer.doNotSellData']),
-                className: 'ccpa-show-settings',
+                href: `${MARKETING_BASE_URL}${localePrefix}/edx-privacy-policy/cookies`,
+                title: intl.formatMessage(messages['footer.legalLinks.cookiePolicy']),
+              },
+              {
+                title: intl.formatMessage(messages['footer.legalLinks.doNotSellData']),
+                className: 'px-0',
                 onClick: this.CCPADialogOpen,
+                variant: 'link',
+                size: 'inline',
               },
             ]}
           />

--- a/src/components/Footer.messages.js
+++ b/src/components/Footer.messages.js
@@ -101,6 +101,16 @@ const messages = defineMessages({
     defaultMessage: 'Sitemap',
     description: 'The label for the link to the edX sitemap page.',
   },
+  'footer.legalLinks.doNotSellData': {
+    id: 'footer.legalLinks.doNotSellData',
+    defaultMessage: 'Do Not Sell My Personal Data',
+    description: 'link button that leads to the "Do Not Sell My Personal Data" cookie settings menu.',
+  },
+  'footer.legalLinks.cookiePolicy': {
+    id: 'footer.legalLinks.cookiePolicy',
+    defaultMessage: 'Cookie Policy',
+    description: 'link button that leads to the edX "Cookie Policy" page',
+  },
   'footer.connectLinks.heading': {
     id: 'footer.connectLinks.heading',
     defaultMessage: 'Connect',
@@ -155,11 +165,6 @@ const messages = defineMessages({
     id: 'footer.ariaLabel',
     defaultMessage: 'Page Footer',
     description: 'aria-label for the footer component',
-  },
-  'footer.doNotSellData': {
-    id: 'footer.doNotSellData',
-    defaultMessage: 'Do Not Sell My Personal Data',
-    description: 'link button that leads to the cookie settings menu',
   },
 });
 

--- a/src/components/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/__snapshots__/Footer.test.jsx.snap
@@ -184,8 +184,15 @@ exports[`<Footer /> renders correctly renders with a language selector 1`] = `
           </a>
         </li>
         <li>
+          <a
+            href="https://edx.org/edx-privacy-policy/cookies"
+          >
+            Cookie Policy
+          </a>
+        </li>
+        <li>
           <button
-            className="ccpa-show-settings btn btn-primary"
+            className="px-0 btn btn-link btn-inline"
             disabled={false}
             onClick={[Function]}
             type="button"
@@ -587,8 +594,15 @@ exports[`<Footer /> renders correctly renders without a language selector 1`] = 
           </a>
         </li>
         <li>
+          <a
+            href="https://edx.org/edx-privacy-policy/cookies"
+          >
+            Cookie Policy
+          </a>
+        </li>
+        <li>
           <button
-            className="ccpa-show-settings btn btn-primary"
+            className="px-0 btn btn-link btn-inline"
             disabled={false}
             onClick={[Function]}
             type="button"
@@ -955,8 +969,15 @@ exports[`<Footer /> renders correctly renders without a language selector in es 
           </a>
         </li>
         <li>
+          <a
+            href="https://edx.org/es/edx-privacy-policy/cookies"
+          >
+            Cookie Policy
+          </a>
+        </li>
+        <li>
           <button
-            className="ccpa-show-settings btn btn-primary"
+            className="px-0 btn btn-link btn-inline"
             disabled={false}
             onClick={[Function]}
             type="button"


### PR DESCRIPTION
This will be released to to `latest` (v5.1.1) as well as backported to v4.5.6, v4.6.3, and v4.7.5.