### PR TITLE
fix: CCPA btn link styles

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -194,7 +194,7 @@ class Footer extends React.Component {
               },
               {
                 title: intl.formatMessage(messages['footer.legalLinks.doNotSellData']),
-                className: 'px-0',
+                className: 'px-0 text-left text-decoration-none',
                 onClick: this.CCPADialogOpen,
                 variant: 'link',
                 size: 'inline',

--- a/src/components/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/__snapshots__/Footer.test.jsx.snap
@@ -192,7 +192,7 @@ exports[`<Footer /> renders correctly renders with a language selector 1`] = `
         </li>
         <li>
           <button
-            className="px-0 btn btn-link btn-inline"
+            className="px-0 text-left text-decoration-none btn btn-link btn-inline"
             disabled={false}
             onClick={[Function]}
             type="button"
@@ -602,7 +602,7 @@ exports[`<Footer /> renders correctly renders without a language selector 1`] = 
         </li>
         <li>
           <button
-            className="px-0 btn btn-link btn-inline"
+            className="px-0 text-left text-decoration-none btn btn-link btn-inline"
             disabled={false}
             onClick={[Function]}
             type="button"
@@ -977,7 +977,7 @@ exports[`<Footer /> renders correctly renders without a language selector in es 
         </li>
         <li>
           <button
-            className="px-0 btn btn-link btn-inline"
+            className="px-0 text-left text-decoration-none btn btn-link btn-inline"
             disabled={false}
             onClick={[Function]}
             type="button"


### PR DESCRIPTION
Looks some MFEs (e.g., frontend-app-account) override`.btn-link`'s `text-decoration` property which interferes with the CCPA button link in the footer. Example:

<img width="1206" alt="image" src="https://user-images.githubusercontent.com/2828721/208685155-ad9efa18-062b-464b-b8d3-3c573d6969c4.png">

In order to get around this for now, adding `text-left` and `text-decoration-none` will ensure the button link styles we expect in the footer come through regardless of any custom CSS overrides in the MFE itself.