### PR TITLE
feat: hide app download buttons when page accessed from edx mobile apps

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -59,6 +59,9 @@ class Footer extends React.Component {
     });
   }
 
+  // Added specific check for edX mobile app
+  isMobile = () => navigator.userAgent.match('org.edx.mobile');
+
   getLocalePrefix(locale) {
     const twoLetterPrefix = locale.substring(0, 2).toLowerCase();
     if (twoLetterPrefix === 'en') {
@@ -233,6 +236,7 @@ class Footer extends React.Component {
             <ul className="d-flex flex-row justify-content-between list-unstyled max-width-222 p-0 mb-4">
               <SocialIconLinks onClick={this.externalLinkClickHandler} />
             </ul>
+            {!this.isMobile() && (
             <ul className="d-flex flex-row justify-content-between list-unstyled max-width-264 p-0 mb-5">
               <li>
                 <GooglePlayStoreButton onClick={this.externalLinkClickHandler} />
@@ -241,6 +245,7 @@ class Footer extends React.Component {
                 <AppleAppStoreButton onClick={this.externalLinkClickHandler} />
               </li>
             </ul>
+            )}
             <p>
               © {new Date().getFullYear()} edX LLC. All rights reserved.
               <br />

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -59,9 +59,6 @@ class Footer extends React.Component {
     });
   }
 
-  // Added specific check for edX mobile app
-  isMobile = () => navigator.userAgent.match('org.edx.mobile');
-
   getLocalePrefix(locale) {
     const twoLetterPrefix = locale.substring(0, 2).toLowerCase();
     if (twoLetterPrefix === 'en') {
@@ -69,6 +66,9 @@ class Footer extends React.Component {
     }
     return `/${twoLetterPrefix}`;
   }
+
+  // Added specific check for edX mobile app
+  isMobile = () => navigator.userAgent.match('org.edx.mobile');
 
   externalLinkClickHandler(event) {
     const label = event.currentTarget.getAttribute('href');


### PR DESCRIPTION
[Remove Play/App Store badges from Delete Account Webview Page](https://2u-internal.atlassian.net/browse/LEARNER-9214)

It will hide download app buttons from footer if accessed from edX's mobile apps. Identifier of mobile apps is **app ID**(`org.edx.mobile`) passed in the userAgent from both apps