### PR TITLE
Remove unused tranisfex v2 url 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ transifex_langs = "ar,fr,es_419,zh_CN,pt,it,de,uk,ru,hi,fr_CA"
 transifex_utils = ./node_modules/.bin/transifex-utils.js
 i18n = ./src/i18n
 transifex_input = $(i18n)/transifex_input.json
-tx_url1 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transifex_resource)/translation/en/strings/
-tx_url2 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transifex_resource)/source/
 
 # This directory must match .babelrc .
 transifex_temp = ./temp/babel-plugin-react-intl


### PR DESCRIPTION
Ticket:
[Updating /api/v2 transifex endpoints](https://github.com/edx/edx-arch-experiments/issues/202)

There was no need for tx-url1 and tx-url2 because transifex has already migrated from v2 to v3.