### PR TITLE
feat: increase range for paragon version support to 20.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "redux": "4.2.1"
       },
       "peerDependencies": {
-        "@edx/paragon": "^20.20.0",
+        "@edx/paragon": "^20.0.0",
         "prop-types": "^15.7.0",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "js-cookie": "^3.0.1"
   },
   "peerDependencies": {
-    "@edx/paragon": "^20.20.0",
+    "@edx/paragon": "^20.0.0",
     "prop-types": "^15.7.0",
     "react": "^16.9.0 || ^17.0.0",
     "react-dom": "^16.9.0 || ^17.0.0"


### PR DESCRIPTION
Peer dependency for `20.20.0` feel arbitrary. It should support for wider range assuming there isn't breaking change in `20.x.x`.
