### PR TITLE
SEO-576: Update the blog link in MFE footers

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -205,7 +205,7 @@ class Footer extends React.Component {
             title={intl.formatMessage(messages['footer.connectLinks.heading'])}
             links={[
               {
-                href: 'https://blog.edx.org',
+                href: 'https://www.edx.org/resources',
                 title: intl.formatMessage(messages['footer.connectLinks.blog']),
               },
               {

--- a/src/components/Footer.messages.js
+++ b/src/components/Footer.messages.js
@@ -118,8 +118,8 @@ const messages = defineMessages({
   },
   'footer.connectLinks.blog': {
     id: 'footer.connectLinks.blog',
-    defaultMessage: 'Blog',
-    description: 'The label for the link to the edX blog.',
+    defaultMessage: 'Idea Hub',
+    description: 'The label for the link to the edX idea hub page.',
   },
   'footer.connectLinks.contact': {
     id: 'footer.connectLinks.contact',


### PR DESCRIPTION
Changed blog link to /resources and text to Idea Hub:

https://github.com/edx/frontend-component-footer-edx/assets/131785062/eb56c1e3-72d4-48d3-8669-4eaf08d7788d

JIRA:
[SEO-576](https://2u-internal.atlassian.net/browse/SEO-576)

